### PR TITLE
Minor updates to pngpread.c, pngrutil.c

### DIFF
--- a/DiligentTools/ThirdParty/lpng-1.6.17/pngpread.c
+++ b/DiligentTools/ThirdParty/lpng-1.6.17/pngpread.c
@@ -245,6 +245,21 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
       if ((png_ptr->mode & PNG_AFTER_IDAT) != 0)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
+   else // FIX ADDED: owencqueen, 03/28/2021
+   {
+     png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+   	  if (png_ptr->user_chunk_malloc_max > 0 &&
+    	    png_ptr->user_chunk_malloc_max < limit)
+      	  limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+     	    limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+        	png_chunk_error(png_ptr, "chunk data is too large");
+   }
+ 
 
    if (chunk_name == png_IHDR)
    {

--- a/DiligentTools/ThirdParty/lpng-1.6.17/pngrutil.c
+++ b/DiligentTools/ThirdParty/lpng-1.6.17/pngrutil.c
@@ -175,6 +175,23 @@ png_read_chunk_header(png_structrp png_ptr)
    /* Check to see if chunk name is valid. */
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 
+	 //Addition: owencqueen, 03/28/2021
+   /* Check for too-large chunk length */
+   if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+
 #ifdef PNG_IO_STATE_SUPPORTED
    png_ptr->io_state = PNG_IO_READING | PNG_IO_CHUNK_DATA;
 #endif


### PR DESCRIPTION
I have gone through and added some updates that were made in libpng's recent updates (commit 347538efbdc21b8df684ebd92d37400b3ce85d55). These are minor changes that should provide capability for a user limit on the size of chunks of png files read.